### PR TITLE
Uncommented constraints and solve

### DIFF
--- a/en/examples/aust.mzn
+++ b/en/examples/aust.mzn
@@ -4,16 +4,17 @@ int: nc = 3;
 var 1..nc: wa;   var 1..nc: nt;  var 1..nc: sa;   var 1..nc: q;
 var 1..nc: nsw;  var 1..nc: v;   var 1..nc: t;
 
-%constraint wa != nt;
-%constraint wa != sa;
-%constraint nt != sa;
-%constraint nt != q;
-%constraint sa != q;
-%constraint sa != nsw;
-%constraint sa != v;
-%constraint q != nsw;
-%constraint nsw != v;
-%solve satisfy;
+constraint wa != nt;
+constraint wa != sa;
+constraint nt != sa;
+constraint nt != q;
+constraint sa != q;
+constraint sa != nsw;
+constraint sa != v;
+constraint q != nsw;
+constraint nsw != v;
+
+solve satisfy;
 
 output ["wa=\(wa)\t nt=\(nt)\t sa=\(sa)\n",
         "q=\(q)\t nsw=\(nsw)\t v=\(v)\n",


### PR DESCRIPTION
At first I would like to thank the authors for the great work done.
I enjoy using this software and the documentation is really great.

This is a minor thing I noticed while reading the docs.

The constraints and solve lines should normally be part of the example.
- The constraints are part of the example problem's modelling .
- The "solve satisfy;" line  will be implied even if commented, it makes sense to have it is more readable if it is explicitly mentioned.