### PR TITLE
Fix set type in grammar

### DIFF
--- a/chi/grammar.mzn
+++ b/chi/grammar.mzn
@@ -81,7 +81,7 @@
 <ti-variable-expr-tail> ::= $[A-Za-z][A-Za-z0-9_]*
 
 % Set type-inst expressions
-<set-ti-expr-tail> ::= "set" "of" <base-type>
+<set-ti-expr-tail> ::= "set" "of" <ti-expr>
 
 % Array type-inst expressions
 <array-ti-expr-tail> ::= "array" [ <ti-expr> "," ... ] "of" <ti-expr>

--- a/en/grammar.mzn
+++ b/en/grammar.mzn
@@ -81,7 +81,7 @@
 <ti-variable-expr-tail> ::= $[A-Za-z][A-Za-z0-9_]*
 
 % Set type-inst expressions
-<set-ti-expr-tail> ::= "set" "of" <base-type>
+<set-ti-expr-tail> ::= "set" "of" <ti-expr>
 
 % Array type-inst expressions
 <array-ti-expr-tail> ::= "array" [ <ti-expr> "," ... ] "of" <ti-expr>

--- a/es/grammar.mzn
+++ b/es/grammar.mzn
@@ -81,7 +81,7 @@
 <ti-variable-expr-tail> ::= $[A-Za-z][A-Za-z0-9_]*
 
 % Set type-inst expressions
-<set-ti-expr-tail> ::= "set" "of" <base-type>
+<set-ti-expr-tail> ::= "set" "of" <ti-expr>
 
 % Array type-inst expressions
 <array-ti-expr-tail> ::= "array" [ <ti-expr> "," ... ] "of" <ti-expr>


### PR DESCRIPTION
MiniZinc seems to accept `ti-expr`s, instead of just `base-type`s, as type parameters for sets (similar to arrays and lists). This PR fixes that in the grammar.