### PR TITLE
fix int-literal to include negative integers

### DIFF
--- a/chi/fzn-grammar.mzn
+++ b/chi/fzn-grammar.mzn
@@ -69,9 +69,9 @@
                  | "true"
 
 % Integer literals
-<int-literal> ::= [0-9]+
-                | 0x[0-9A-Fa-f]+
-                | 0o[0-7]+
+<int-literal> ::= [-][0-9]+
+                | [-]0x[0-9A-Fa-f]+
+                | [-]0o[0-7]+
 
 % Float literals
 <float-literal> ::= [0-9]+.[0-9]+

--- a/chi/grammar.mzn
+++ b/chi/grammar.mzn
@@ -154,9 +154,9 @@
 <bool-literal> ::= "false" | "true"
 
 % Integer literals
-<int-literal> ::= [0-9]+
-                | 0x[0-9A-Fa-f]+
-                | 0o[0-7]+
+<int-literal> ::= [-][0-9]+
+                | [-]0x[0-9A-Fa-f]+
+                | [-]0o[0-7]+
 
 % Float literals
 <float-literal> ::= [0-9]+"."[0-9]+

--- a/en/fzn-grammar.mzn
+++ b/en/fzn-grammar.mzn
@@ -69,9 +69,9 @@
                  | "true"
 
 % Integer literals
-<int-literal> ::= [0-9]+
-                | 0x[0-9A-Fa-f]+
-                | 0o[0-7]+
+<int-literal> ::= [-][0-9]+
+                | [-]0x[0-9A-Fa-f]+
+                | [-]0o[0-7]+
 
 % Float literals
 <float-literal> ::= [0-9]+.[0-9]+

--- a/en/grammar.mzn
+++ b/en/grammar.mzn
@@ -154,9 +154,9 @@
 <bool-literal> ::= "false" | "true"
 
 % Integer literals
-<int-literal> ::= [0-9]+
-                | 0x[0-9A-Fa-f]+
-                | 0o[0-7]+
+<int-literal> ::= [-][0-9]+
+                | [-]0x[0-9A-Fa-f]+
+                | [-]0o[0-7]+
 
 % Float literals
 <float-literal> ::= [0-9]+"."[0-9]+

--- a/es/grammar.mzn
+++ b/es/grammar.mzn
@@ -154,9 +154,9 @@
 <bool-literal> ::= "false" | "true"
 
 % Integer literals
-<int-literal> ::= [0-9]+
-                | 0x[0-9A-Fa-f]+
-                | 0o[0-7]+
+<int-literal> ::= [-][0-9]+
+                | [-]0x[0-9A-Fa-f]+
+                | [-]0o[0-7]+
 
 % Float literals
 <float-literal> ::= [0-9]+"."[0-9]+


### PR DESCRIPTION
While reading the flatzinc specs I realized that the grammar rules for `<int-literal>` do not cover negative integers. I'm not sure whether this is the appropriate place to submit this patch. Please let me know if I should file an issue in another place.